### PR TITLE
Text wrapping

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
@@ -130,8 +130,10 @@ public class BranchFileViewActivity extends BaseActivity implements
         loadingBar = finder.find(R.id.pb_loading);
         codeView = finder.find(R.id.wv_code);
 
-        codeView.getSettings().setBuiltInZoomControls(true);
-        codeView.getSettings().setUseWideViewPort(true);
+//        The default settings supported pinch gestures for zooming in and out
+//        But did not support text wrapping
+//        codeView.getSettings().setBuiltInZoomControls(true);
+//        codeView.getSettings().setUseWideViewPort(true);
 
         file = CommitUtils.getName(path);
         isMarkdownFile = MarkdownUtils.isMarkdown(file);
@@ -177,8 +179,11 @@ public class BranchFileViewActivity extends BaseActivity implements
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.m_wrap:
-                if (editor.getWrap())
+                if (editor.getWrap()) {
                     item.setTitle(R.string.enable_wrapping);
+                    //Modified setting here to toggle between wrap text and unwrap text
+                    codeView.getSettings().setBuiltInZoomControls(true);
+                }
                 else
                     item.setTitle(R.string.disable_wrapping);
                 editor.toggleWrap();

--- a/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
@@ -181,7 +181,7 @@ public class BranchFileViewActivity extends BaseActivity implements
             case R.id.m_wrap:
                 if (editor.getWrap()) {
                     item.setTitle(R.string.enable_wrapping);
-                    //Modified setting here to toggle between wrap text and unwrap text
+                    //Modified setting here to toggle between wrapping text and unwrapping text
                     codeView.getSettings().setBuiltInZoomControls(true);
                 }
                 else


### PR DESCRIPTION
Initially, the action bar menu will allow the user to select enable wrapping but the text did not wrap. Instead, it just changed the text to disable wrapping. Modified the WebView settings to support text wrapping and accurately reflect the menu options.
