### PR TITLE
Open readme in browser

### DIFF
--- a/app/res/menu/file_view.xml
+++ b/app/res/menu/file_view.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   Copyright 2012 GitHub Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,22 +14,26 @@
   limitations under the License.
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <item
-    android:id="@+id/m_wrap"
-    app:showAsAction="never"
-    android:title="@string/enable_wrapping"/>
-  <item
-    android:id="@+id/m_render_markdown"
-    android:enabled="false"
-    app:showAsAction="never"
-    android:title="@string/render_markdown"
-    android:visible="false"/>
-  <item
-    android:id="@+id/m_share"
-    android:icon="@drawable/abc_ic_menu_share_mtrl_alpha"
-    app:showAsAction="never"
-    android:title="@string/share"/>
+    <item
+        android:id="@+id/m_wrap"
+        android:title="@string/enable_wrapping"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/m_render_markdown"
+        android:enabled="false"
+        android:title="@string/render_markdown"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/m_share"
+        android:icon="@drawable/abc_ic_menu_share_mtrl_alpha"
+        android:title="@string/share"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/m_open_in_browser"
+        android:title="@string/open_in_browser"
+        app:showAsAction="never" />
 
 </menu>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -288,6 +288,7 @@
     <string name="render_markdown">Render markdown</string>
     <string name="copy_hash">Copy hash</string>
     <string name="toast_msg_copied">Copied to clipboard</string>
+    <string name="open_in_browser">Open in Browser</string>
 
     <!-- Navigation drawer strings -->
     <string name="navigation_drawer_open">Open navigation drawer</string>

--- a/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
@@ -37,6 +37,7 @@ import com.github.mobile.ui.MarkdownLoader;
 import com.github.mobile.util.AvatarLoader;
 import com.github.mobile.util.HttpImageGetter;
 import com.github.mobile.util.MarkdownUtils;
+import com.github.mobile.util.OpenBrowserUtils;
 import com.github.mobile.util.PreferenceUtils;
 import com.github.mobile.util.ShareUtils;
 import com.github.mobile.util.SourceEditor;
@@ -190,6 +191,10 @@ public class BranchFileViewActivity extends BaseActivity implements
                 shareFile();
                 return true;
 
+            case R.id.m_open_in_browser:
+                openBrowser();
+                return true;
+
             case R.id.m_render_markdown:
                 if (editor.isMarkdown()) {
                     item.setTitle(R.string.render_markdown);
@@ -245,6 +250,11 @@ public class BranchFileViewActivity extends BaseActivity implements
         String id = repo.generateId();
         startActivity(ShareUtils.create(path + " at " + branch + " on " + id,
             "https://github.com/" + id + "/blob/" + branch + '/' + path));
+    }
+
+    private void openBrowser() {
+        String id = repo.generateId();
+        startActivity(OpenBrowserUtils.create("https://github.com/" + id + "/blob/" + branch + '/' + path));
     }
 
     private void loadMarkdown() {

--- a/app/src/main/java/com/github/mobile/util/OpenBrowserUtils.java
+++ b/app/src/main/java/com/github/mobile/util/OpenBrowserUtils.java
@@ -1,0 +1,39 @@
+package com.github.mobile.util;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import static android.content.Intent.ACTION_SEND;
+import static android.content.Intent.EXTRA_SUBJECT;
+import static android.content.Intent.EXTRA_TEXT;
+
+/**
+ * Created by jaellysbales on 6/19/15.
+ * Utilities for opening file in browser.
+ */
+public class OpenBrowserUtils {
+
+    /**
+     * Create intent with file URL
+     *
+     * @param url
+     * @return intent
+     */
+    public static Intent create(final String url) {
+        String fileUrl = url;
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(url));
+        return intent;
+    }
+
+    /**
+     * Get URL from intent
+     *
+     * @param intent
+     * @return url
+     */
+    public static String getBody(final Intent intent) {
+        return intent != null ? intent.getStringExtra(Intent.ACTION_VIEW) : null;
+    }
+}

--- a/app/src/main/java/com/github/mobile/util/OpenBrowserUtils.java
+++ b/app/src/main/java/com/github/mobile/util/OpenBrowserUtils.java
@@ -2,11 +2,6 @@ package com.github.mobile.util;
 
 import android.content.Intent;
 import android.net.Uri;
-import android.text.TextUtils;
-
-import static android.content.Intent.ACTION_SEND;
-import static android.content.Intent.EXTRA_SUBJECT;
-import static android.content.Intent.EXTRA_TEXT;
 
 /**
  * Created by jaellysbales on 6/19/15.


### PR DESCRIPTION
See https://github.com/accesscode-2-1/android/issues/19

Added menu option to open file in browser. Working on second user's request (adding readme as separate section in tab layout nav) because I think it's valid, but it's proving a bit trickier. Want to make my pull request just in case.
